### PR TITLE
Fix Crash When 'Content-Disposition' Header Is Missing

### DIFF
--- a/api/utils/storage/HTTPStorage.py
+++ b/api/utils/storage/HTTPStorage.py
@@ -25,10 +25,13 @@ class HTTPStorage(BaseStorage):
         print(f"Downloading {self.url} to {fname}...")
         resp = requests.get(self.url, stream=True)
         total = int(resp.headers.get("content-length", 0))
-        content_disposition = resp.headers["content-disposition"]
-        filename_search = re.search('filename="(.+)"', content_disposition)
-        if filename_search:
-            self.filename = filename_search.group(1)
+        content_disposition = resp.headers.get("content-disposition") 
+        if content_disposition:
+            filename_search = re.search('filename="(.+)"', content_disposition)
+            if filename_search:
+                self.filename = filename_search.group(1)
+        else:
+            print('Warning: content-disposition header is not found in the response.')
         # Can also replace 'file' with a io.BytesIO object
         with open(fname, "wb") as file, tqdm(
             desc="Downloading",


### PR DESCRIPTION
This pull request addresses an issue in the HTTPStorage class, specifically in the `download_file` method. Previously, the method would fail and crash if the 'content-disposition' header was missing from the HTTP response. This is a common scenario, especially when dealing with servers that don't include this optional header.

- Modified the `download_file` method in `HTTPStorage` to use the `get` method when accessing `resp.headers["content-disposition"]`. This will return `None` instead of raising an exception if the header is missing.
- Added a conditional check to ensure that the content disposition header is not `None` before attempting to parse it with a regular expression.

This fix will prevent the application from crashing when attempting to download files from servers that do not include a 'content-disposition' header. The application's robustness and reliability will be improved, especially in diverse server environments.